### PR TITLE
Fix: Resolve infinite redirect loop in middleware

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,20 @@ const nextConfig = {
       },
     ];
   },
+
+  // Handle rewrites for static files
+  async rewrites() {
+    return [
+      {
+        source: '/llms.txt',
+        destination: '/llms.txt',
+      },
+      {
+        source: '/llms-full.txt',
+        destination: '/llms-full.txt',
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,8 +35,8 @@ export default function RootLayout({
 }>) {
   return (
     // The lang attribute will be handled by the [locale] layout
-    <html>
-      <body className={inter.className}>
+    <html suppressHydrationWarning>
+      <body className={inter.className} suppressHydrationWarning>
         {children}
         <SpeedInsights />
       </body>


### PR DESCRIPTION
- Configure next-intl middleware with localePrefix: 'as-needed' to prevent redirect loops
- Improve middleware matcher to exclude static files properly
- Add explicit handling for llms.txt files
- Simplify Next.js config rewrites for static files
- Add suppressHydrationWarning to prevent hydration conflicts